### PR TITLE
fix: allow usage with EAP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ intellijRunIde = "2024.2"
 intellijPlugin = "1.17.4"
 intellijSinceBuild = "231"
 # set to "999.*" to disable upper bound
-intellijUntilBuild = "242.*"
+intellijUntilBuild = "243.*"
 # Grammar-Kit isn't compatible with 1.7.0-2
 jflex = "1.7.0-1"
 # use same version that ships with `intellijSinceBuild`


### PR DESCRIPTION
A small PR to bump the `intellijUntilBuild` property to allow usage with the Intellij EAP